### PR TITLE
Refactor axios response interceptor: comment out 401 error handling and update access/refresh token extraction

### DIFF
--- a/src/utils/axiosConfig.js
+++ b/src/utils/axiosConfig.js
@@ -53,6 +53,7 @@ axiosConfig.interceptors.response.use(
             Cookies.set('accessToken', newAccessToken);
             Cookies.set('refreshToken', newRefreshToken);
             axiosConfig.defaults.headers.Authorization = `Bearer ${newAccessToken}`;
+            window.location.reload();
             return axiosConfig(originalRequest);
           })
           .catch((error) => {

--- a/src/utils/axiosConfig.js
+++ b/src/utils/axiosConfig.js
@@ -29,12 +29,12 @@ axiosConfig.interceptors.response.use(
     return response;
   },
   async (error) => {
-    if (error.response?.status === 401) {
-      const refreshToken = Cookies.get('refreshToken');
-      await AuthService.logout(refreshToken).then(() => {
-        window.location.href = '/signin';
-      });
-    }
+    // if (error.response?.status === 401) {
+    //   const refreshToken = Cookies.get('refreshToken');
+    //   await AuthService.logout(refreshToken).then(() => {
+    //     window.location.href = '/signin';
+    //   });
+    // }
 
     // if (error.response?.status !== 410) {
     //   toast.error(error.response?.data?.message || error?.message);
@@ -47,15 +47,18 @@ axiosConfig.interceptors.response.use(
 
         refreshTokenPromise = await AuthService.refreshAccessToken(refreshToken)
           .then((response) => {
-            const newAccessToken = response.tokens.access.token;
+            console.log('Response:', response);
+            const newAccessToken = response.data.access.token;
+            const newRefreshToken = response.data.refresh.token;
             Cookies.set('accessToken', newAccessToken);
+            Cookies.set('refreshToken', newRefreshToken);
             axiosConfig.defaults.headers.Authorization = `Bearer ${newAccessToken}`;
             return axiosConfig(originalRequest);
           })
           .catch((error) => {
-            AuthService.logout(refreshToken).then(() => {
-              window.location.href = '/signin';
-            });
+            // AuthService.logout(refreshToken).then(() => {
+            //   window.location.href = '/signin';
+            // });
           })
           .finally(() => {
             refreshTokenPromise = null;


### PR DESCRIPTION
This pull request includes changes to the `src/utils/axiosConfig.js` file, focusing on handling token refresh logic and error handling. The most important changes involve commenting out the logout functionality and updating the token refresh logic to include both access and refresh tokens.

Error handling adjustments:

* Commented out the logout functionality when a 401 status error occurs, which previously redirected users to the sign-in page.

Token refresh logic updates:

* Added logging for the response received during token refresh and updated the code to handle both access and refresh tokens by storing them in cookies.