### PR TITLE
Add react-signature-canvas dependency and implement signature approval feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.26.2",
         "react-scripts": "5.0.1",
+        "react-signature-canvas": "^1.0.6",
         "react-toastify": "^10.0.5",
         "vn-provinces": "^1.0.4",
         "web-vitals": "^2.1.4"
@@ -17144,6 +17145,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-signature-canvas": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.0.6.tgz",
+      "integrity": "sha512-NoMHomYu9HxFeLjUGbIeV9abPdWSROfFxFNDekGdwmmaIx+w5ziOEiU2C34X0Ao4GxFnwqyUy/BpYlA4lCD1CA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "signature_pad": "^2.3.2",
+        "trim-canvas": "^0.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.8",
+        "react": "0.14 - 18",
+        "react-dom": "0.14 - 18"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
@@ -18093,6 +18109,12 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/signature_pad": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
+      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -19180,6 +19202,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/trim-canvas": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
+      "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.26.2",
     "react-scripts": "5.0.1",
+    "react-signature-canvas": "^1.0.6",
     "react-toastify": "^10.0.5",
     "vn-provinces": "^1.0.4",
     "web-vitals": "^2.1.4"

--- a/src/components/modals/HistoryDetailModal.js
+++ b/src/components/modals/HistoryDetailModal.js
@@ -1,12 +1,12 @@
+import React, { useEffect, useState } from 'react';
+import { Box, IconButton, Modal, Typography } from '@mui/material';
 import { ArrowBack, PictureAsPdf, PhotoRounded } from '@mui/icons-material';
-import { Backdrop, Box, CircularProgress, IconButton, Modal, Typography } from '@mui/material';
-import React, { useEffect, useRef, useState } from 'react';
 import { dark, red, black, white, gray, yellow, blue, green } from '../../config/theme/themePrimitives';
+import { toast } from 'react-toastify';
 import NotaryStep from './NotaryStep';
 import NotaryFeedback from '../services/NotaryFeedback.js';
 import useWindowSize from '../../hooks/useWindowSize';
 import NotarizationService from '../../services/notarization.service.js';
-import { toast } from 'react-toastify';
 
 const InfoRow = ({ label, value }) => (
   <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
@@ -31,13 +31,8 @@ const Section = ({ title, children }) => (
   </Box>
 );
 
-const HistoryDetailModal = ({ open, handleClose, data, notaryId, load }) => {
-  let notarizationData;
-
-  data.forEach((element) => {
-    if (element._id === notaryId) notarizationData = element;
-  });
-
+const HistoryDetailModal = ({ open, handleClose, data, notaryId }) => {
+  const notarizationData = data.find((item) => item._id === notaryId);
   const [currentStep, setCurrentStep] = useState(0);
   const [loadingSignature, setLoadingSignature] = useState(false);
   const [documentFiles, setDocumentFiles] = useState([]);
@@ -52,13 +47,16 @@ const HistoryDetailModal = ({ open, handleClose, data, notaryId, load }) => {
     setLoadingSignature(true);
     try {
       await NotarizationService.approveSignatureByUser(formData);
-      setLoadingSignature(false);
       toast.success('Lưu chữ ký thành công');
     } catch (error) {
       setLoadingSignature(false);
       if (error.status === 409) {
         toast.error('Tài liệu này đã được ký số');
+      } else {
+        toast.error('Đã xảy ra lỗi khi lưu chữ ký');
       }
+    } finally {
+      setLoadingSignature(false);
     }
   };
 
@@ -89,111 +87,51 @@ const HistoryDetailModal = ({ open, handleClose, data, notaryId, load }) => {
     );
   };
 
-  const renderDocumentFiles = (file) => {
-    return (
-      <Box
-        sx={{
-          p: 1,
-          display: 'flex',
-          flexDirection: 'row',
-          gap: 2,
-          borderRadius: 1,
-          boxShadow: 1,
-          border: `1px solid ${black[50]}`,
-          alignItems: 'center',
-          width: 'fit-content',
-        }}
-      >
-        <Box
-          sx={{
-            borderRadius: 100,
-            backgroundColor: red[50],
-            justifyContent: 'center',
-            alignItems: 'center',
-            display: 'flex',
-            p: 1,
-          }}
-        >
-          <PictureAsPdf sx={{ fontSize: 14, color: red[500] }} />
-        </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            minWidth: '100px',
-            overflow: 'clip',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          <Typography
-            onClick={() => window.open(file.firebaseUrl)}
-            sx={{
-              flex: 1,
-              fontSize: 12,
-              fontWeight: 500,
-              cursor: 'pointer',
-              ':hover': {
-                textDecoration: 'underline',
-              },
-            }}
-          >
-            {file.filename}
-          </Typography>
-        </Box>
-      </Box>
-    );
-  };
+  const renderFile = (file, isImage) => {
+    const iconConfig = isImage
+      ? { bgColor: yellow[50], color: yellow[500], Icon: PhotoRounded }
+      : { bgColor: red[50], color: red[500], Icon: PictureAsPdf };
 
-  const renderImageFiles = (file) => {
     return (
       <Box
+        key={file.filename}
         sx={{
-          p: 1,
           display: 'flex',
-          flexDirection: 'row',
           gap: 2,
+          p: 1,
           borderRadius: 1,
-          boxShadow: 1,
           border: `1px solid ${black[50]}`,
           alignItems: 'center',
+          boxShadow: 1,
           width: 'fit-content',
         }}
       >
         <Box
           sx={{
+            backgroundColor: iconConfig.bgColor,
+            color: iconConfig.color,
             borderRadius: 100,
-            backgroundColor: yellow[50],
+            display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
-            display: 'flex',
             p: 1,
           }}
         >
-          <PhotoRounded sx={{ fontSize: 14, color: yellow[500] }} />
+          <iconConfig.Icon sx={{ fontSize: 14 }} />
         </Box>
-        <Box
+        <Typography
+          onClick={() => window.open(file.firebaseUrl)}
           sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            minWidth: '100px',
-            overflow: 'clip',
+            fontSize: 12,
+            fontWeight: 500,
+            cursor: 'pointer',
             textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            ':hover': { textDecoration: 'underline' },
           }}
         >
-          <Typography
-            sx={{
-              flex: 1,
-              fontSize: 12,
-              fontWeight: 500,
-              cursor: 'pointer',
-              ':hover': {
-                textDecoration: 'underline',
-              },
-            }}
-          >
-            {file.filename}
-          </Typography>
-        </Box>
+          {file.filename}
+        </Typography>
       </Box>
     );
   };
@@ -202,11 +140,9 @@ const HistoryDetailModal = ({ open, handleClose, data, notaryId, load }) => {
     if (notarizationData?.files) {
       const [docs, images] = notarizationData.files.reduce(
         ([docAcc, imgAcc], file) => {
-          if (['.pdf', '.docx'].some((ext) => file.filename?.toString().toLowerCase().endsWith(ext))) {
-            docAcc.push(file);
-          } else if (['.png', '.jpg', '.jpeg'].some((ext) => file.filename?.toString().toLowerCase().endsWith(ext))) {
-            imgAcc.push(file);
-          }
+          const filename = file.filename?.toLowerCase();
+          if (filename?.endsWith('.pdf') || filename?.endsWith('.docx')) docAcc.push(file);
+          if (['.png', '.jpg', '.jpeg'].some((ext) => filename?.endsWith(ext))) imgAcc.push(file);
           return [docAcc, imgAcc];
         },
         [[], []],
@@ -215,168 +151,119 @@ const HistoryDetailModal = ({ open, handleClose, data, notaryId, load }) => {
       setImageFiles(images);
     }
 
-    if (notarizationData.status.status === 'pending') setCurrentStep(0);
-    if (notarizationData.status.status === 'processing') setCurrentStep(1);
-    if (notarizationData.status.status === 'verification') setCurrentStep(2);
-    if (notarizationData.status.status === 'digitalSignature') setCurrentStep(3);
-    if (notarizationData.status.status === 'completed') setCurrentStep(4);
+    const statusSteps = {
+      pending: 0,
+      processing: 1,
+      verification: 2,
+      digitalSignature: 3,
+      completed: 4,
+    };
+
+    setCurrentStep(statusSteps[notarizationData?.status?.status] ?? 0);
   }, [notarizationData]);
 
   return (
     <Modal open={open} onClose={handleClose} aria-labelledby="modal-modal-title" aria-describedby="modal-modal-description">
       <Box>
-        {load ? (
+        <Box>
           <Box
             sx={{
               position: 'absolute',
               top: '50%',
               left: '50%',
               transform: 'translate(-50%, -50%)',
-              width: `${width}px - 20%`,
-              height: `${height}px - 50%`,
+              width: `calc(${width}px - 20%)`,
+              height: `calc(${height}px - 20%)`,
               backgroundColor: white[50],
               borderRadius: 2,
               overflowY: 'scroll',
               display: 'flex',
+              flexDirection: 'column',
               boxShadow: 1,
               p: 2,
               gap: 1,
-              alignItems: 'center',
-              justifyContent: 'center',
+              scrollbarWidth: { xs: 'none', sm: 'auto' },
             }}
           >
-            <CircularProgress></CircularProgress>
-          </Box>
-        ) : (
-          <Box>
+            {/* Header Section */}
             <Box
               sx={{
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
-                width: `calc(${width}px - 20%)`,
-                height: `calc(${height}px - 20%)`,
-                backgroundColor: white[50],
-                borderRadius: 2,
-                overflowY: 'scroll',
                 display: 'flex',
-                flexDirection: 'column',
-                boxShadow: 1,
-                p: 2,
+                justifyContent: 'space-between',
+                alignItems: { xs: 'flex-start', sm: 'center' },
+                flexDirection: { xs: 'column', sm: 'row' },
                 gap: 1,
-                scrollbarWidth: { xs: 'none', sm: 'auto' },
               }}
             >
-              {/* Header Section */}
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: { xs: 'flex-start', sm: 'center' },
-                  flexDirection: { xs: 'column', sm: 'row' },
-                  gap: 1,
-                }}
-              >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                  <IconButton onClick={handleClose}>
-                    <ArrowBack
-                      sx={{
-                        color: black[900],
-                      }}
-                      fontSize="small"
-                    />
-                  </IconButton>
-                  <Box
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                <IconButton onClick={handleClose}>
+                  <ArrowBack
                     sx={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: { xs: 'flex-start', sm: 'center' },
-                      flexDirection: { xs: 'column', sm: 'row' },
-                      gap: 1,
-                      width: '100%',
+                      color: black[900],
                     }}
-                  >
-                    <Typography sx={{ fontSize: 'clamp(14px, 2vw, 16px)', fontWeight: 600, color: black[900] }}>
-                      Chi tiết hồ sơ công chứng {notarizationData._id && `- Mã số: #${notarizationData._id}`}
-                    </Typography>
-                    {renderStatusBox(notarizationData.status.status)}
-                  </Box>
+                    fontSize="small"
+                  />
+                </IconButton>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: { xs: 'flex-start', sm: 'center' },
+                    flexDirection: { xs: 'column', sm: 'row' },
+                    gap: 1,
+                    width: '100%',
+                  }}
+                >
+                  <Typography sx={{ fontSize: 'clamp(14px, 2vw, 16px)', fontWeight: 600, color: black[900] }}>
+                    Chi tiết hồ sơ công chứng {notarizationData._id && `- Mã số: #${notarizationData._id}`}
+                  </Typography>
+                  {renderStatusBox(notarizationData.status.status)}
                 </Box>
               </Box>
-              {/* User Information Section */}
-              <Section title="Thông tin khách hàng">
-                <InfoRow label="Họ và tên:" value={notarizationData?.requesterInfo?.fullName} />
-                <InfoRow label="Số CMND/CCCD:" value={notarizationData?.requesterInfo?.citizenId} />
-                <InfoRow label="Số điện thoại:" value={notarizationData?.requesterInfo?.phoneNumber} />
-                <InfoRow label="Email:" value={notarizationData?.requesterInfo?.email} />
-              </Section>
-
-              {/* Notarization Information Section */}
-              <Section title="Thông tin công chứng">
-                <InfoRow label="Lĩnh vực công chứng:" value={notarizationData?.notarizationField?.name} />
-                <InfoRow label="Dịch vụ công chứng:" value={notarizationData?.notarizationService?.name} />
-              </Section>
-
-              {/* Files Section */}
-              {documentFiles.length > 0 && (
-                <Section title={'Tệp'}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'space-between',
-                      gap: 1,
-                      flex: 1,
-                    }}
-                  >
-                    {documentFiles.map((file) => renderDocumentFiles(file))}
-                  </Box>
-                </Section>
-              )}
-
-              {/* Images Section */}
-              {imageFiles.length > 0 && (
-                <Section title={'Ảnh'}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'space-between',
-                      gap: 1,
-                      flex: 1,
-                    }}
-                  >
-                    {imageFiles.map((file) => renderImageFiles(file))}
-                  </Box>
-                </Section>
-              )}
-
-              {notarizationData.status.status !== undefined && (
-                <>
-                  {/* Steps Section */}
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'row',
-                      gap: 4,
-                      p: { xs: 0, sm: 2 },
-                    }}
-                  >
-                    <NotaryStep currentStep={currentStep} />
-                    <NotaryFeedback
-                      signature={notarizationData.signature}
-                      output={notarizationData.output}
-                      feedback={notarizationData.status.feedback}
-                      onSignatureSave={handleSignatureSave}
-                      loading={loadingSignature}
-                    />
-                  </Box>
-                </>
-              )}
             </Box>
+            {/* User Information Section */}
+            <Section title="Thông tin khách hàng">
+              <InfoRow label="Họ và tên:" value={notarizationData?.requesterInfo?.fullName} />
+              <InfoRow label="Số CMND/CCCD:" value={notarizationData?.requesterInfo?.citizenId} />
+              <InfoRow label="Số điện thoại:" value={notarizationData?.requesterInfo?.phoneNumber} />
+              <InfoRow label="Email:" value={notarizationData?.requesterInfo?.email} />
+            </Section>
+
+            {/* Notarization Information Section */}
+            <Section title="Thông tin công chứng">
+              <InfoRow label="Lĩnh vực công chứng:" value={notarizationData?.notarizationField?.name} />
+              <InfoRow label="Dịch vụ công chứng:" value={notarizationData?.notarizationService?.name} />
+            </Section>
+
+            {documentFiles.length > 0 && (
+              <Section title="Tệp">{documentFiles.map((file) => renderFile(file, false))}</Section>
+            )}
+            {imageFiles.length > 0 && <Section title="Ảnh">{imageFiles.map((file) => renderFile(file, true))}</Section>}
+
+            {notarizationData.status.status !== undefined && (
+              <>
+                {/* Steps Section */}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    gap: 4,
+                    p: { xs: 0, sm: 2 },
+                  }}
+                >
+                  <NotaryStep currentStep={currentStep} />
+                  <NotaryFeedback
+                    signature={notarizationData.signature}
+                    output={notarizationData.output}
+                    feedback={notarizationData.status.feedback}
+                    onSignatureSave={handleSignatureSave}
+                    loading={loadingSignature}
+                  />
+                </Box>
+              </>
+            )}
           </Box>
-        )}
+        </Box>
       </Box>
     </Modal>
   );

--- a/src/components/modals/NotaryStep.js
+++ b/src/components/modals/NotaryStep.js
@@ -66,6 +66,7 @@ const NotaryStep = ({ currentStep }) => {
                   fontWeight: index === currentStep ? 'bold' : 'normal',
                   fontSize: 12,
                   cursor: 'pointer',
+                  textWrap: 'nowrap',
                 }}
               >
                 {step.label}

--- a/src/components/services/NotaryFeedback.js
+++ b/src/components/services/NotaryFeedback.js
@@ -1,13 +1,13 @@
 import { ErrorRounded, FiberManualRecordRounded, HelpRounded, OpenInNewRounded, WarningRounded } from '@mui/icons-material';
 import { Box, Button, CircularProgress, Typography } from '@mui/material';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import { red, black, white, yellow, gray } from '../../config/theme/themePrimitives';
 import { getDocumentNameByCode } from '../../utils/constants';
 import SignatureCanvas from 'react-signature-canvas';
 import useWindowSize from '../../hooks/useWindowSize';
 
 const NotaryFeedback = ({ signature, output, feedback, onSignatureSave, loading }) => {
-  const { width, height } = useWindowSize();
+  const { width } = useWindowSize();
   const sigCanvasRef = useRef(null);
 
   const onClear = () => {

--- a/src/components/services/NotaryFeedback.js
+++ b/src/components/services/NotaryFeedback.js
@@ -101,6 +101,7 @@ const NotaryFeedback = ({ signature, output, feedback, onSignatureSave, loading 
                   textDecoration: 'underline',
                 },
               }}
+              onClick={() => window.open(item.firebaseUrl, '_blank')}
             >
               {item.filename}
             </Typography>
@@ -112,37 +113,48 @@ const NotaryFeedback = ({ signature, output, feedback, onSignatureSave, loading 
   };
 
   const renderSignaturePad = () => {
-    if (output && !signature?.approvalStatus.user.approved) {
-      return (
-        <Box sx={{ backgroundColor: gray[50], mt: 2, px: 2, py: 1, borderRadius: 1 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <Typography sx={{ fontSize: 12, fontWeight: 500 }}>Điền chữ ký của bạn vào phần dưới đây</Typography>
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button variant="text" onClick={onClear}>
-                <Typography sx={{ fontSize: 12, fontWeight: 500, color: black[900], textTransform: 'none' }}>
-                  Huỷ bỏ
-                </Typography>
-              </Button>
-              <Button variant="contained" onClick={onSave}>
-                {loading ? (
-                  <CircularProgress size={20} color="inherit" />
-                ) : (
-                  <Typography sx={{ fontSize: 12, fontWeight: 500, color: white[50], textTransform: 'none' }}>
-                    Lưu thay đổi
+    if (output) {
+      if (!signature?.approvalStatus.user.approved) {
+        return (
+          <Box sx={{ backgroundColor: gray[50], mt: 2, px: 2, py: 1, borderRadius: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Typography sx={{ fontSize: 12, fontWeight: 500 }}>Điền chữ ký của bạn vào phần dưới đây</Typography>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button variant="text" onClick={onClear}>
+                  <Typography sx={{ fontSize: 12, fontWeight: 500, color: black[900], textTransform: 'none' }}>
+                    Huỷ bỏ
                   </Typography>
-                )}
-              </Button>
+                </Button>
+                <Button variant="contained" onClick={onSave}>
+                  {loading ? (
+                    <CircularProgress size={20} color="inherit" />
+                  ) : (
+                    <Typography sx={{ fontSize: 12, fontWeight: 500, color: white[50], textTransform: 'none' }}>
+                      Lưu thay đổi
+                    </Typography>
+                  )}
+                </Button>
+              </Box>
+            </Box>
+            <Box sx={{ backgroundColor: white[50], borderRadius: 1, border: `1px solid ${black[50]}`, mt: 1 }}>
+              <SignatureCanvas
+                ref={sigCanvasRef}
+                penColor="black"
+                canvasProps={{ width: width - 600, height: 300, className: 'sigCanvas' }}
+              />
             </Box>
           </Box>
-          <Box sx={{ backgroundColor: white[50], borderRadius: 1, border: `1px solid ${black[50]}`, mt: 1 }}>
-            <SignatureCanvas
-              ref={sigCanvasRef}
-              penColor="black"
-              canvasProps={{ width: width - 600, height: 300, className: 'sigCanvas' }}
-            />
+        );
+      } else if (signature?.signatureImage !== null) {
+        return (
+          <Box sx={{ backgroundColor: gray[50], mt: 2, px: 2, py: 1, borderRadius: 1 }}>
+            <Typography sx={{ fontSize: 12, fontWeight: 500 }}>Chữ ký của bạn</Typography>
+            <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+              <img src={signature.signatureImage} alt="Your signature" />
+            </Box>
           </Box>
-        </Box>
-      );
+        );
+      }
     }
   };
 

--- a/src/components/services/NotaryFeedback.js
+++ b/src/components/services/NotaryFeedback.js
@@ -15,8 +15,9 @@ const NotaryFeedback = ({ signature, output, feedback, onSignatureSave, loading 
   };
 
   const onSave = () => {
-    const trimmedDataURL = sigCanvasRef.current.getTrimmedCanvas().toDataURL('image/png');
-    onSignatureSave(trimmedDataURL);
+    sigCanvasRef.current.getTrimmedCanvas().toBlob((blob) => {
+      onSignatureSave(blob);
+    });
   };
 
   const { content, type, missingFiles } = useMemo(() => {

--- a/src/pages/services/HistoryNotarizationProfile.js
+++ b/src/pages/services/HistoryNotarizationProfile.js
@@ -1,159 +1,114 @@
-import React, { useEffect, useState } from 'react';
-import { Box, Typography, Button, TextField, InputAdornment, Grid } from '@mui/material';
-import 'react-toastify/dist/ReactToastify.css';
-import FindInPageIcon from '@mui/icons-material/FindInPage';
-import SearchIcon from '@mui/icons-material/Search';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box, Typography, TextField, InputAdornment } from '@mui/material';
 import { white, black } from '../../config/theme/themePrimitives';
 import StatusFilterButton from '../../components/services/StatusFilterButton';
 import HistoryDataTable from '../../components/services/HistoryDataTable';
 import NotarizationService from '../../services/notarization.service';
 import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import SkeletonHistoryDataTable from '../../components/services/SkeletonHistoryDataTable';
-import { useNavigate } from 'react-router-dom';
-import AppsIcon from '@mui/icons-material/Apps';
-import HourglassTopIcon from '@mui/icons-material/HourglassTop';
-import LoopIcon from '@mui/icons-material/Loop';
-import EditNoteIcon from '@mui/icons-material/EditNote';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import ErrorIcon from '@mui/icons-material/Error';
-import VerifiedIcon from '@mui/icons-material/Verified';
+import {
+  AppsRounded,
+  CheckCircleRounded,
+  EditNoteRounded,
+  ErrorRounded,
+  HourglassTopRounded,
+  LoopRounded,
+  SearchRounded,
+} from '@mui/icons-material';
+import { STATUS_TYPES } from '../../utils/constants';
+
+const ICON_MAP = {
+  [STATUS_TYPES.All]: <AppsRounded sx={{ height: '18px', width: '18px' }} />,
+  [STATUS_TYPES.Pending]: <HourglassTopRounded sx={{ height: '18px', width: '18px' }} />,
+  [STATUS_TYPES.Processing]: <LoopRounded sx={{ height: '18px', width: '18px' }} />,
+  [STATUS_TYPES.DigitalSignature]: <EditNoteRounded sx={{ height: '18px', width: '18px' }} />,
+  [STATUS_TYPES.Completed]: <CheckCircleRounded sx={{ height: '18px', width: '18px' }} />,
+  [STATUS_TYPES.Rejected]: <ErrorRounded sx={{ height: '18px', width: '18px' }} />,
+};
+
+const HEAD_CELLS = [
+  { id: 'profile', disablePadding: true, label: 'Số hồ sơ' },
+  { id: 'date', disablePadding: false, label: 'Ngày công chứng' },
+  { id: 'name', disablePadding: false, label: 'Người yêu cầu' },
+  { id: 'status', disablePadding: false, label: 'Tình trạng' },
+  { id: 'service', disablePadding: false, label: 'Loại dịch vụ' },
+];
+
+const createData = (id, profile, date, name, status, service) => ({
+  id,
+  profile,
+  date,
+  name,
+  status,
+  service,
+});
 
 const HistoryNotarizationProfile = () => {
-  const statusTypes = {
-    All: 'Tất cả',
-    Pending: 'Chờ xử lý',
-    Processing: 'Đang xử lý',
-    DigitalSignature: 'Sẵn sàng ký số',
-    Completed: 'Hoàn tất',
-    Rejected: 'Không hợp lệ',
-  };
-
-  const iconMap = {
-    [statusTypes.All]: <AppsIcon sx={{ height: '18px', width: '18px' }} />,
-    [statusTypes.Pending]: <HourglassTopIcon sx={{ height: '18px', width: '18px' }} />,
-    [statusTypes.Processing]: <LoopIcon sx={{ height: '18px', width: '18px' }} />,
-    [statusTypes.DigitalSignature]: <EditNoteIcon sx={{ height: '18px', width: '18px' }} />,
-    [statusTypes.Completed]: <CheckCircleIcon sx={{ height: '18px', width: '18px' }} />,
-    [statusTypes.Rejected]: <ErrorIcon sx={{ height: '18px', width: '18px' }} />,
-  };
-
-  const headCells = [
-    {
-      id: 'profile',
-      disablePadding: true,
-      label: 'Số hồ sơ',
-    },
-    {
-      id: 'date',
-      disablePadding: false,
-      label: 'Ngày công chứng',
-    },
-    {
-      id: 'name',
-      disablePadding: false,
-      label: 'Người yêu cầu',
-    },
-    {
-      id: 'status',
-      disablePadding: false,
-      label: 'Tình trạng',
-    },
-    {
-      id: 'service',
-      disablePadding: false,
-      label: 'Loại dịch vụ',
-    },
-  ];
-
-  function createData(id, profile, date, name, status, service) {
-    return {
-      id,
-      profile,
-      date,
-      name,
-      status,
-      service,
-    };
-  }
-
-  const [statusFilter, setStatusFilter] = useState(statusTypes.All);
-  const [statusClicked, setStatusClicked] = useState(statusTypes.All);
+  const [statusFilter, setStatusFilter] = useState(STATUS_TYPES.All);
+  const [statusClicked, setStatusClicked] = useState(STATUS_TYPES.All);
   const [searchText, setSearchText] = useState('');
   const [loadingStatus, setLoadingStatus] = useState(false);
   const [rows, setRows] = useState([]);
   const [fullData, setFullData] = useState([]);
-  const navigate = useNavigate();
 
-  async function getHistoryFromDB() {
+  const fetchHistory = useCallback(async () => {
     try {
       setLoadingStatus(true);
       const response = await NotarizationService.getHistory();
       setFullData(response);
 
-      const data = await Promise.all(
-        response.map(async (item, index) => {
-          const date = new Date(item.createdAt);
-          const notaryDate = date.getDate() + '/' + (date.getMonth() + 1) + '/' + date.getFullYear();
-          let status;
+      const formattedData = response.map((item, index) => {
+        const date = new Date(item.createdAt);
+        const notaryDate = `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`;
+        const statusMap = {
+          pending: 'Chờ xử lý',
+          processing: 'Đang xử lý',
+          verification: 'Đang xác minh',
+          digitalSignature: 'Sẵn sàng ký số',
+          completed: 'Hoàn tất',
+          rejected: 'Không hợp lệ',
+        };
+        return createData(
+          index + 1,
+          item._id,
+          notaryDate,
+          item.requesterInfo.fullName,
+          statusMap[item.status.status],
+          item.notarizationService.name,
+        );
+      });
 
-          if (item.status.status === 'pending') status = 'Chờ xử lý';
-          if (item.status.status === 'processing') status = 'Đang xử lý';
-          if (item.status.status === 'verification') status = 'Đang xác minh';
-          if (item.status.status === 'digitalSignature') status = 'Sẵn sàng ký số';
-          if (item.status.status === 'completed') status = 'Hoàn tất';
-          if (item.status.status === 'rejected') status = 'Không hợp lệ';
-          return createData(
-            index + 1,
-            item._id,
-            notaryDate,
-            item.requesterInfo.fullName,
-            status,
-            item.notarizationService.name,
-          );
-        }),
-      );
-      setRows(data);
-      console.log(data);
-      setLoadingStatus(false);
+      setRows(formattedData);
     } catch (error) {
-      if (error.response && error.response.status === 401) {
+      if (error.response?.status === 401) {
         toast.error('Vui lòng đăng nhập');
       }
+    } finally {
+      setLoadingStatus(false);
     }
-  }
-
-  function setStatusColor(params) {
-    let color = '';
-    let backgroundColor = '';
-    if (params === 'Chờ xử lý') {
-      color = '#324155';
-      backgroundColor = '#EBEDEF';
-    } else if (params === 'Đang xử lý') {
-      color = '#FFAA00';
-      backgroundColor = '#FFF7E6';
-    } else if (params === 'Đang xác minh') {
-      color = '#7007C1';
-      backgroundColor = '#F9F0FF';
-    } else if (params === 'Sẵn sàng ký số') {
-      color = '#0095FF';
-      backgroundColor = '#E6F4FF';
-    } else if (params === 'Hoàn tất') {
-      color = '#43B75D';
-      backgroundColor = '#ECF8EF';
-    } else if (params === 'Không hợp lệ') {
-      color = '#EE443F';
-      backgroundColor = '#FDECEC';
-    }
-    return { color, backgroundColor };
-  }
-
-  useEffect(() => {
-    getHistoryFromDB();
   }, []);
 
-  const handleClick = () => {
-    navigate('/lookup');
+  const handleFilterChange = (status) => {
+    setStatusFilter(status);
+    setStatusClicked(status);
   };
+
+  const getStatusStyles = (status) => {
+    const styles = {
+      'Chờ xử lý': { color: '#324155', backgroundColor: '#EBEDEF' },
+      'Đang xử lý': { color: '#FFAA00', backgroundColor: '#FFF7E6' },
+      'Đang xác minh': { color: '#7007C1', backgroundColor: '#F9F0FF' },
+      'Sẵn sàng ký số': { color: '#0095FF', backgroundColor: '#E6F4FF' },
+      'Hoàn tất': { color: '#43B75D', backgroundColor: '#ECF8EF' },
+      'Không hợp lệ': { color: '#EE443F', backgroundColor: '#FDECEC' },
+    };
+    return styles[status] || {};
+  };
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100vh' }}>
@@ -202,61 +157,15 @@ const HistoryNotarizationProfile = () => {
               borderBottom: '1px solid #C0C0C0',
             }}
           >
-            <StatusFilterButton
-              statusFilter={statusTypes.All}
-              handleFilterByStatus={() => {
-                setStatusFilter(statusTypes.All);
-                setStatusClicked(statusTypes.All);
-              }}
-              clickedButton={statusClicked}
-              iconMap={iconMap}
-            ></StatusFilterButton>
-
-            <StatusFilterButton
-              statusFilter={statusTypes.Pending}
-              handleFilterByStatus={() => {
-                setStatusFilter(statusTypes.Pending);
-                setStatusClicked(statusTypes.Pending);
-              }}
-              clickedButton={statusClicked}
-              iconMap={iconMap}
-            />
-            <StatusFilterButton
-              statusFilter={statusTypes.Processing}
-              handleFilterByStatus={() => {
-                setStatusFilter(statusTypes.Processing);
-                setStatusClicked(statusTypes.Processing);
-              }}
-              clickedButton={statusClicked}
-              iconMap={iconMap}
-            />
-            <StatusFilterButton
-              statusFilter={statusTypes.DigitalSignature}
-              handleFilterByStatus={() => {
-                setStatusFilter(statusTypes.DigitalSignature);
-                setStatusClicked(statusTypes.DigitalSignature);
-              }}
-              clickedButton={statusClicked}
-              iconMap={iconMap}
-            />
-            <StatusFilterButton
-              statusFilter={statusTypes.Completed}
-              handleFilterByStatus={() => {
-                setStatusFilter(statusTypes.Completed);
-                setStatusClicked(statusTypes.Completed);
-              }}
-              clickedButton={statusClicked}
-              iconMap={iconMap}
-            />
-            <StatusFilterButton
-              statusFilter={statusTypes.Rejected}
-              handleFilterByStatus={() => {
-                setStatusFilter(statusTypes.Rejected);
-                setStatusClicked(statusTypes.Rejected);
-              }}
-              clickedButton={statusClicked}
-              iconMap={iconMap}
-            />
+            {Object.keys(STATUS_TYPES).map((key) => (
+              <StatusFilterButton
+                key={key}
+                statusFilter={STATUS_TYPES[key]}
+                handleFilterByStatus={() => handleFilterChange(STATUS_TYPES[key])}
+                clickedButton={statusClicked}
+                iconMap={ICON_MAP}
+              />
+            ))}
           </Box>
 
           <Box sx={{ flex: 1, display: { xs: 'none', sm: 'none', md: 'flex' } }}></Box>
@@ -278,32 +187,25 @@ const HistoryNotarizationProfile = () => {
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
-                  <SearchIcon sx={{ color: black[300] }} />
+                  <SearchRounded sx={{ color: black[300] }} />
                 </InputAdornment>
               ),
             }}
           ></TextField>
         </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            border: !loadingStatus ? '1px solid var(--black-50, #E0E0E0)' : 'none',
-            borderRadius: '8px',
-            background: white[50],
-          }}
-        >
+        <Box sx={{ border: !loadingStatus ? '1px solid #E0E0E0' : 'none', borderRadius: '8px', background: white[50] }}>
           {loadingStatus ? (
-            <SkeletonHistoryDataTable headCells={headCells}></SkeletonHistoryDataTable>
+            <SkeletonHistoryDataTable headCells={HEAD_CELLS} />
           ) : (
             <HistoryDataTable
               filterStatus={statusFilter}
               searchText={searchText}
               rows={rows}
-              headCells={headCells}
-              statusTypes={statusTypes}
-              setStatusColor={setStatusColor}
+              headCells={HEAD_CELLS}
+              statusTypes={STATUS_TYPES}
+              setStatusColor={getStatusStyles}
               data={fullData}
-            ></HistoryDataTable>
+            />
           )}
         </Box>
       </Box>

--- a/src/services/notarization.service.js
+++ b/src/services/notarization.service.js
@@ -93,7 +93,9 @@ const getAllNotarizations = async (sortBy = null, limit, page) => {
 
 const getNotarizationByRole = async ({ status, page, limit }) => {
   try {
-    const response = await axiosConfig.get(`${NOTARIZATION_ENDPOINT}/getDocumentByRole`, { params: { status, page, limit } });
+    const response = await axiosConfig.get(`${NOTARIZATION_ENDPOINT}/getDocumentByRole`, {
+      params: { status, page, limit },
+    });
     return response.data;
   } catch (error) {
     const status = error.response?.status;
@@ -111,7 +113,7 @@ const getApproveHistory = async () => {
     const message = error.response?.data?.message;
     return { status, message };
   }
-}
+};
 
 const getDocumentById = async (documentId) => {
   try {
@@ -122,25 +124,33 @@ const getDocumentById = async (documentId) => {
     const message = error.response?.data?.message;
     return { status, message };
   }
-}
+};
 
 const forwardDocumentStatus = async (documentId, formData) => {
   try {
-    const response = await axiosConfig.patch(`${NOTARIZATION_ENDPOINT}/forwardDocumentStatus/${documentId}`,
-      formData,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      }
-    );
+    const response = await axiosConfig.patch(`${NOTARIZATION_ENDPOINT}/forwardDocumentStatus/${documentId}`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
     return response.data;
   } catch (error) {
     const status = error.response?.status;
     const message = error.response?.data?.message;
     return { status, message };
   }
-}
+};
+
+const approveSignatureByUser = async (formData) => {
+  try {
+    const response = await axiosConfig.post(`${NOTARIZATION_ENDPOINT}/approve-signature-by-user`, formData);
+    return response;
+  } catch (error) {
+    const status = error.response?.status;
+    const message = error.response?.data?.message;
+    return { status, message };
+  }
+};
 
 const approveSignatureByNotary = async (documentId) => {
   try {
@@ -149,9 +159,9 @@ const approveSignatureByNotary = async (documentId) => {
   } catch (error) {
     const status = error.response?.status;
     const message = error.response?.data?.message;
-    return { status, message }
+    return { status, message };
   }
-}
+};
 
 const NotarizationService = {
   getStatusById,
@@ -165,6 +175,7 @@ const NotarizationService = {
   getApproveHistory,
   getDocumentById,
   forwardDocumentStatus,
+  approveSignatureByUser,
   approveSignatureByNotary,
 };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -29,4 +29,13 @@ export const DOCUMENT_TYPE_LABELS = {
   default: 'Tài liệu không xác định',
 };
 
+export const STATUS_TYPES = {
+  All: 'Tất cả',
+  Pending: 'Chờ xử lý',
+  Processing: 'Đang xử lý',
+  DigitalSignature: 'Sẵn sàng ký số',
+  Completed: 'Hoàn tất',
+  Rejected: 'Không hợp lệ',
+};
+
 export const getDocumentNameByCode = (code) => DOCUMENT_TYPE_LABELS[code] || DOCUMENT_TYPE_LABELS.default;


### PR DESCRIPTION
This pull request includes several changes to add signature functionality and improve the user interface in the notarization components. The most important changes include adding a new dependency, updating the `HistoryDetailModal` component, and extending the `NotaryFeedback` component to handle signatures.

### Dependency Addition:
* Added `react-signature-canvas` to `package.json` to enable signature capture functionality.

### Component Updates:
* `src/components/modals/HistoryDetailModal.js`:
  * Added `useRef` and `toast` imports.
  * Introduced `handleSignatureSave` function to save user signatures.
  * Updated `NotaryFeedback` component to include signature handling props. [[1]](diffhunk://#diff-e3679d2f9041a1ab590ce6d351cbb0b06d2af7c687c8acd29afc03ed8a64e4e2L3-R9) [[2]](diffhunk://#diff-e3679d2f9041a1ab590ce6d351cbb0b06d2af7c687c8acd29afc03ed8a64e4e2L40-R64) [[3]](diffhunk://#diff-e3679d2f9041a1ab590ce6d351cbb0b06d2af7c687c8acd29afc03ed8a64e4e2L346-L360)

* `src/components/services/NotaryFeedback.js`:
  * Added `SignatureCanvas` and new state management for handling signature input.
  * Implemented `renderSignaturePad` and `renderOutputSection` functions to display signature pad and output documents. [[1]](diffhunk://#diff-0e3343d68728d1394444f6a31e675563ef5e409c4e9fd34e6acf1c67deb1c804L1-L7) [[2]](diffhunk://#diff-0e3343d68728d1394444f6a31e675563ef5e409c4e9fd34e6acf1c67deb1c804R62-L57) [[3]](diffhunk://#diff-0e3343d68728d1394444f6a31e675563ef5e409c4e9fd34e6acf1c67deb1c804R207-R208)

### Service Updates:
* `src/services/notarization.service.js`:
  * Added `approveSignatureByUser` function to handle signature approval requests.
  * Refactored existing functions to improve code readability and consistency. [[1]](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L96-R98) [[2]](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L114-R116) [[3]](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L125-R153) [[4]](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L152-R164) [[5]](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1R178)