### PR TITLE
Add CreateNotaryAccountModal

### DIFF
--- a/src/pages/admin/employee-management/CreateNotaryAccountModal.js
+++ b/src/pages/admin/employee-management/CreateNotaryAccountModal.js
@@ -1,0 +1,161 @@
+import { Box, Button, Modal, TextField, Typography } from '@mui/material'
+import React from 'react'
+import { black, gray, primary, red, white } from '../../../config/theme/themePrimitives'
+import UserService from '../../../services/user.service'
+import { toast } from 'react-toastify'
+
+const CreateNotaryAccountModal = ({ open, onClose }) => {
+    const [name, setName] = React.useState('')
+    const [email, setEmail] = React.useState('')
+    const [password, setPassword] = React.useState('')
+
+    const handleCreateAccount = async () => {
+        const user = {
+            name,
+            email,
+            password,
+            role: 'notary',
+        }
+        const response = await UserService.createUserAccount(user)
+        if (response.status === 201) {
+            onClose();
+            toast.success('Tạo tài khoản thành công')
+        } else {
+            toast.error('Tạo tài khoản thất bại')
+        }
+    }
+
+    return (
+        <Modal
+            open={open}
+            onClose={onClose}
+            aria-labelledby="modal-modal-title"
+            aria-describedby="modal-modal-description"
+        >
+            <Box
+                sx={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    width: '40vw',
+                    bgcolor: 'background.paper',
+                    padding: 4,
+                    borderRadius: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '20px',
+                }}
+            >
+                <Typography variant="h6" sx={{ fontWeight: 500 }}>
+                    Tạo tài khoản nhân viên
+                </Typography>
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '16px',
+                    }}
+                >
+                    <TextField
+                        label="Họ và tên"
+                        type='text'
+                        variant="outlined"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        sx={{
+                            '& .MuiInputBase-root': {
+                                '& fieldset': {
+                                    borderColor: gray[200],
+                                },
+                                '&:hover fieldset': {
+                                    borderColor: black[900],
+                                },
+                                '&.Mui-focused fieldset': {
+                                    borderColor: black[900],
+                                    borderWidth: 1,
+                                },
+                            },
+                            '& .MuiAutocomplete-tag': {
+                                backgroundColor: gray[200],
+                                color: black[900],
+                            },
+                        }}
+                    />
+
+                    <TextField
+                        label="Email"
+                        type='email'
+                        variant="outlined"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        sx={{
+                            '& .MuiInputBase-root': {
+                                '& fieldset': {
+                                    borderColor: gray[200],
+                                },
+                                '&:hover fieldset': {
+                                    borderColor: black[900],
+                                },
+                                '&.Mui-focused fieldset': {
+                                    borderColor: black[900],
+                                    borderWidth: 1,
+                                },
+                            },
+                            '& .MuiAutocomplete-tag': {
+                                backgroundColor: gray[200],
+                                color: black[900],
+                            },
+                        }}
+                    />
+
+                    <TextField
+                        label="Mật khẩu"
+                        type='text'
+                        variant="outlined"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        sx={{
+                            '& .MuiInputBase-root': {
+                                '& fieldset': {
+                                    borderColor: gray[200],
+                                },
+                                '&:hover fieldset': {
+                                    borderColor: black[900],
+                                },
+                                '&.Mui-focused fieldset': {
+                                    borderColor: black[900],
+                                    borderWidth: 1,
+                                },
+                            },
+                            '& .MuiAutocomplete-tag': {
+                                backgroundColor: gray[200],
+                                color: black[900],
+                            },
+                        }}
+                    />
+                </Box>
+                <Button
+                    sx={{
+                        backgroundColor: primary[500],
+                        color: white[50],
+                        '&:hover': {
+                            backgroundColor: primary[700],
+                        },
+                        textTransform: 'none',
+                        fontSize: '16px',
+                        fontWeight: 500,
+                        padding: '8px 16px',
+                        borderRadius: 1,
+                    }}
+                    onClick={handleCreateAccount}
+                >
+                    Tạo tài khoản
+                </Button>
+            </Box>
+        </Modal>
+    )
+}
+
+export default CreateNotaryAccountModal

--- a/src/pages/admin/employee-management/Header.js
+++ b/src/pages/admin/employee-management/Header.js
@@ -1,23 +1,46 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
-import { white } from '../../../config/theme/themePrimitives';
+import { Box, Button, Typography } from '@mui/material';
+import { white, primary } from '../../../config/theme/themePrimitives';
+import CreateNotaryAccountModal from './CreateNotaryAccountModal';
 
 const Header = () => {
+  const [open, setOpen] = React.useState(false);
+
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        p: 2,
-        gap: '8px',
-        backgroundColor: white[50],
-      }}
-    >
-      <Box sx={{ flex: 1, gap: 2 }}>
-        <Typography variant="h6" sx={{ fontWeight: 500 }}>
-          Quản lý nhân viên
-        </Typography>
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          p: 2,
+          gap: '8px',
+          backgroundColor: white[50],
+        }}
+      >
+        <Box sx={{ flex: 1, gap: 2 }}>
+          <Typography variant="h6" sx={{ fontWeight: 500 }}>
+            Quản lý nhân viên
+          </Typography>
+        </Box>
+        <Button
+          sx={{
+            backgroundColor: primary[500],
+            color: white[50],
+            '&:hover': {
+              backgroundColor: primary[700],
+            },
+            textTransform: 'none',
+            fontSize: '16px',
+            fontWeight: 500,
+            padding: '4px 16px',
+            borderRadius: 1,
+          }}
+          onClick={() => setOpen(true)}
+        >
+          Thêm nhân viên
+        </Button>
       </Box>
-    </Box>
+      <CreateNotaryAccountModal open={open} onClose={() => setOpen(false)} />
+    </>
   );
 };
 export default Header;

--- a/src/pages/admin/notary-management/NotaryManagement.js
+++ b/src/pages/admin/notary-management/NotaryManagement.js
@@ -20,7 +20,7 @@ const NotaryManagement = () => {
   const [totalNotarizations, setTotalNotarizations] = useState(0);
   const [totalSessions, setTotalSessions] = useState(0);
   const [notaryPaginationModel, setNotaryPaginationModel] = useState({
-    pageSize: 25,
+    pageSize: 10,
     page: 0,
   });
   const [sessionPaginationModel, setSessionPaginationModel] = useState({

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -59,11 +59,24 @@ const getAllUsers = async (role = 'user', sortBy = null, limit, page) => {
   }
 }
 
+const createUserAccount = async (user) => {
+  try {
+    const response = await axiosConfig.post(`${USER_ENDPOINT}`, user);
+    return response;
+  } catch (error) {
+    if (error.response) {
+      return error.response.data;
+    }
+    return error.message;
+  }
+}
+
 const UserService = {
   getUserById,
   searchUserByEmail,
   updateUserById,
-  getAllUsers
+  getAllUsers,
+  createUserAccount,
 };
 
 export default UserService;


### PR DESCRIPTION
This pull request introduces a new feature to create notary accounts and includes several related changes across different files. The main additions include a new modal component for creating notary accounts, updates to the header to include a button for opening the modal, and a new service method for creating user accounts.

New feature implementation:

* [`src/pages/admin/employee-management/CreateNotaryAccountModal.js`](diffhunk://#diff-abf95d00bffdc94d0b334604b9fb2ee81c7d1ef10116ebd79a34c40db4b4bf5dR1-R161): Added a new modal component that allows for the creation of notary accounts, including form fields for name, email, and password, and a button to submit the form.

Updates to existing components:

* [`src/pages/admin/employee-management/Header.js`](diffhunk://#diff-e4c94e4fea3775584e0842493a06e46669afa6a3eecc3a6cd72fa42c4f3bc467L2-R10): Added a button to the header for opening the `CreateNotaryAccountModal`, and included the modal in the JSX. [[1]](diffhunk://#diff-e4c94e4fea3775584e0842493a06e46669afa6a3eecc3a6cd72fa42c4f3bc467L2-R10) [[2]](diffhunk://#diff-e4c94e4fea3775584e0842493a06e46669afa6a3eecc3a6cd72fa42c4f3bc467R24-R43)

Service updates:

* [`src/services/user.service.js`](diffhunk://#diff-a2b9ff81ca2fb4f31d8206c9ee37add7698f75d4ed09507b1abd6f97dd63cbefR62-R79): Added a new method `createUserAccount` to the `UserService` for creating user accounts via an API call.

Minor adjustments:

* [`src/pages/admin/notary-management/NotaryManagement.js`](diffhunk://#diff-2bc653a3c6d7879aed76cfa3d2cc81d714dc5cb966b795c59b754cc7005d6deeL23-R23): Changed the default pagination size from 25 to 10 for the notary management page.